### PR TITLE
Feature: Adds admission webhook to `v1beta2` CRD

### DIFF
--- a/api/v1beta2/nodeconfig_webhook_test.go
+++ b/api/v1beta2/nodeconfig_webhook_test.go
@@ -18,30 +18,118 @@ package v1beta2
 
 import (
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/whitestack/node-config-operator/internal/modules"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("NodeConfig Webhook", func() {
-
-	Context("When creating NodeConfig under Defaulting Webhook", func() {
-		It("Should fill in the default value if a required field is empty", func() {
-
-			// TODO(user): Add your logic here
-
-		})
-	})
-
+	var (
+		validator NodeConfigValidator
+	)
 	Context("When creating NodeConfig under Validating Webhook", func() {
-		It("Should deny if a required field is empty", func() {
+		BeforeEach(func() {
+			vSettings := validatorSettings{modulePresent: true}
+			validator = NodeConfigValidator{k8sClient, vSettings}
+			Expect(validator).NotTo(BeNil())
+		})
+		It("Should only allow one NodeConfig with the same modules and same nodeSelector", func() {
+			nc1 := NodeConfig{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test-node-config",
+					Namespace: "default",
+				},
+				Spec: NodeConfigSpec{
+					Hosts: modules.Hosts{
+						Hosts: []modules.Host{
+							{
+								Hostname: "test.com",
+								IP:       "10.0.0.2",
+							},
+						},
+						State: "present",
+					},
+				},
+			}
+			nc2 := NodeConfig{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test-node-config2",
+					Namespace: "default",
+				},
+				Spec: NodeConfigSpec{
+					Hosts: modules.Hosts{
+						Hosts: []modules.Host{
+							{
+								Hostname: "test.com",
+								IP:       "10.0.0.2",
+							},
+						},
+						State: "present",
+					},
+				},
+			}
 
-			// TODO(user): Add your logic here
-
+			err := k8sClient.Create(ctx, &nc1)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = validator.ValidateCreate(ctx, &nc2)
+			Expect(err).NotTo(BeNil())
+			Expect(err.Error()).To(ContainSubstring("hosts module already defined"))
 		})
 
-		It("Should admit if all required fields are provided", func() {
+		It("Should allow NodeConfigs with different NodeSelectors", func() {
+			nc1 := NodeConfig{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test-node-config-selector-1",
+					Namespace: "default",
+				},
+				Spec: NodeConfigSpec{
+					Hosts: modules.Hosts{
+						Hosts: []modules.Host{
+							{
+								Hostname: "test.com",
+								IP:       "10.0.0.2",
+							},
+						},
+						State: "present",
+					},
+					NodeSelector: []v1.LabelSelectorRequirement{
+						{
+							Key:      "test",
+							Operator: v1.LabelSelectorOpIn,
+							Values:   []string{"test"},
+						},
+					},
+				},
+			}
+			nc2 := NodeConfig{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test-node-config-selector-2",
+					Namespace: "default",
+				},
+				Spec: NodeConfigSpec{
+					Hosts: modules.Hosts{
+						Hosts: []modules.Host{
+							{
+								Hostname: "test.com",
+								IP:       "10.0.0.2",
+							},
+						},
+						State: "present",
+					},
+					NodeSelector: []v1.LabelSelectorRequirement{
+						{
+							Key:      "test",
+							Operator: v1.LabelSelectorOpIn,
+							Values:   []string{"test2"},
+						},
+					},
+				},
+			}
 
-			// TODO(user): Add your logic here
-
+			err := k8sClient.Create(ctx, &nc1)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = validator.ValidateCreate(ctx, &nc2)
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
-
 })

--- a/api/v1beta2/utils.go
+++ b/api/v1beta2/utils.go
@@ -1,0 +1,34 @@
+package v1beta2
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func compareSelectors(a, b []metav1.LabelSelectorRequirement) (bool, error) {
+	aLabelSelector := metav1.LabelSelector{
+		MatchExpressions: a,
+	}
+	bLabelSelector := metav1.LabelSelector{
+		MatchExpressions: b,
+	}
+
+	selectorA, err := metav1.LabelSelectorAsSelector(&aLabelSelector)
+	if err != nil {
+		return false, err
+	}
+
+	selectorB, err := metav1.LabelSelectorAsSelector(&bLabelSelector)
+	if err != nil {
+		return false, err
+	}
+
+	return selectorA.String() == selectorB.String(), nil
+}
+
+func getNamespacedNameFromObject(obj metav1.Object) types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: obj.GetNamespace(),
+		Name:      obj.GetName(),
+	}
+}

--- a/chart/templates/daemonset.yaml
+++ b/chart/templates/daemonset.yaml
@@ -38,6 +38,11 @@ spec:
             configMapKeyRef:
               key: APT_ENABLED
               name: {{ include "chart.fullname" . }}-manager-config
+        - name: VALIDATION_MODULE_PRESENT_ENABLED
+          valueFrom:
+            configMapKeyRef:
+              key: VALIDATION_MODULE_PRESENT_ENABLED
+              name: {{ include "chart.fullname" . }}-manager-config
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
         image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag

--- a/chart/templates/manager-config.yaml
+++ b/chart/templates/manager-config.yaml
@@ -7,3 +7,5 @@ metadata:
 data:
   APT_ENABLED: {{ .Values.managerConfig.aptEnabled | quote }}
   HOSTFS_ENABLED: {{ .Values.managerConfig.hostfsEnabled | quote }}
+  VALIDATION_MODULE_PRESENT_ENABLED: {{ .Values.managerConfig.validationModulePresentEnabled
+    | quote }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -19,6 +19,7 @@ kubernetesClusterDomain: cluster.local
 managerConfig:
   aptEnabled: false
   hostfsEnabled: false
+  validationModulePresentEnabled: "true"
 metricsService:
   ports:
   - name: https

--- a/config/manager/config.yaml
+++ b/config/manager/config.yaml
@@ -6,3 +6,4 @@ metadata:
 data:
   HOSTFS_ENABLED: "false"
   APT_ENABLED: "false"
+  VALIDATION_MODULE_PRESENT_ENABLED: "true"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -57,6 +57,11 @@ spec:
             configMapKeyRef:
               name: manager-config
               key: APT_ENABLED
+        - name: VALIDATION_MODULE_PRESENT_ENABLED
+          valueFrom:
+            configMapKeyRef:
+              name: manager-config
+              key: VALIDATION_MODULE_PRESENT_ENABLED
         securityContext:
           privileged: true
         livenessProbe:

--- a/docs/api_docs.md
+++ b/docs/api_docs.md
@@ -107,6 +107,8 @@ _Appears in:_
 | `spec` _[NodeConfigSpec](#nodeconfigspec)_ |  |  |  |
 
 
+
+
 #### NodeConfigList
 
 
@@ -149,6 +151,8 @@ _Appears in:_
 | `crontabs` _[Crontabs](#crontabs)_ | List of Crontabs to schedule |  |  |
 | `grubKernelConfig` _[GrubKernel](#grubkernel)_ | GrubKernelConfig contains kernel version and command line arguments for GRUB configuration |  |  |
 | `nodeSelector` _[LabelSelectorRequirement](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#labelselectorrequirement-v1-meta) array_ | Defines the target nodes for this NodeConfig (optional, default is apply to all nodes) |  |  |
+
+
 
 
 

--- a/internal/modules/apt.go
+++ b/internal/modules/apt.go
@@ -18,6 +18,14 @@ type AptPackages struct {
 	State string `json:"state,omitempty"`
 }
 
+// IsPresent method checks if the module is present
+func (a AptPackages) IsPresent() bool {
+	if len(a.Packages) != 0 && a.State == "present" {
+		return true
+	}
+	return false
+}
+
 type AptPackage struct {
 	Name    string `json:"name"`
 	Version string `json:"version,omitempty"`

--- a/internal/modules/blockinfile.go
+++ b/internal/modules/blockinfile.go
@@ -15,6 +15,14 @@ type BlockInFiles struct {
 	State string `json:"state,omitempty"`
 }
 
+// IsPresent method checks if the module is present
+func (b BlockInFiles) IsPresent() bool {
+	if len(b.Blocks) != 0 && b.State == "present" {
+		return true
+	}
+	return false
+}
+
 type BlockInFile struct {
 	FileName string `json:"filename"`
 	Content  string `json:"content"`

--- a/internal/modules/certificates.go
+++ b/internal/modules/certificates.go
@@ -21,6 +21,14 @@ type Certificates struct {
 	State string `json:"state,omitempty"`
 }
 
+// IsPresent method checks if the module is present
+func (c Certificates) IsPresent() bool {
+	if len(c.Certificates) != 0 && c.State == "present" {
+		return true
+	}
+	return false
+}
+
 type Certificate struct {
 	FileName string `json:"filename"`
 	Content  string `json:"content"`

--- a/internal/modules/crontabs.go
+++ b/internal/modules/crontabs.go
@@ -19,6 +19,14 @@ type Crontabs struct {
 	State string `json:"state,omitempty"`
 }
 
+// IsPresent method checks if the module is present
+func (c Crontabs) IsPresent() bool {
+	if len(c.Entries) != 0 && c.State == "present" {
+		return true
+	}
+	return false
+}
+
 // Crontab defines an individual crontab entry.
 type Crontab struct {
 	// Unique identifier for the cron job

--- a/internal/modules/grubkernelconfig.go
+++ b/internal/modules/grubkernelconfig.go
@@ -28,6 +28,14 @@ type GrubKernel struct {
 	State string `json:"state,omitempty"`
 }
 
+// IsPresent method checks if the module is present
+func (g GrubKernel) IsPresent() bool {
+	if g.KernelVersion != "" && len(g.CmdlineArgs) != 0 && g.State == "present" {
+		return true
+	}
+	return false
+}
+
 type GrubKernelConfig struct {
 	GrubKernel
 	Log logr.Logger

--- a/internal/modules/host.go
+++ b/internal/modules/host.go
@@ -14,6 +14,14 @@ type Hosts struct {
 	State string `json:"state,omitempty"`
 }
 
+// IsPresent method checks if the module is present
+func (h Hosts) IsPresent() bool {
+	if len(h.Hosts) != 0 && h.State == "present" {
+		return true
+	}
+	return false
+}
+
 type Host struct {
 	Hostname string `json:"hostname"`
 	IP       string `json:"ip"`

--- a/internal/modules/kernelmodule.go
+++ b/internal/modules/kernelmodule.go
@@ -18,6 +18,14 @@ type KernelModules struct {
 	State string `json:"state,omitempty"`
 }
 
+// IsPresent method checks if the module is present
+func (k KernelModules) IsPresent() bool {
+	if len(k.Modules) != 0 && k.State == "present" {
+		return true
+	}
+	return false
+}
+
 type KernelModule = string
 
 type KernelModuleConfig struct {

--- a/internal/modules/kernelparameter.go
+++ b/internal/modules/kernelparameter.go
@@ -18,6 +18,14 @@ type KernelParameters struct {
 	State string `json:"state,omitempty"`
 }
 
+// IsPresent method checks if the module is present
+func (k KernelParameters) IsPresent() bool {
+	if len(k.Parameters) != 0 && k.State == "present" {
+		return true
+	}
+	return false
+}
+
 type KernelParameterKV struct {
 	// Name of the kernel parameter (e.g. fs.file-max)
 	Name string `json:"name,omitempty"`

--- a/internal/modules/systemdoverrides.go
+++ b/internal/modules/systemdoverrides.go
@@ -22,6 +22,14 @@ type SystemdOverrides struct {
 	State string `json:"state,omitempty"`
 }
 
+// IsPresent method checks if the module is present
+func (s SystemdOverrides) IsPresent() bool {
+	if len(s.Overrides) != 0 && s.State == "present" {
+		return true
+	}
+	return false
+}
+
 type SystemdOverride struct {
 	// Name of unit to override, must have service or slice suffix
 	Name string `json:"name"`

--- a/internal/modules/systemdunits.go
+++ b/internal/modules/systemdunits.go
@@ -18,6 +18,14 @@ type SystemdUnits struct {
 	State string `json:"state,omitempty"`
 }
 
+// IsPresent method checks if the module is present
+func (s SystemdUnits) IsPresent() bool {
+	if len(s.Units) != 0 && s.State == "present" {
+		return true
+	}
+	return false
+}
+
 type SystemdUnit struct {
 	// Name of the service. A "nco" prefix will be appended
 	Name string `json:"name"`

--- a/patches/00-hosts-if.patch
+++ b/patches/00-hosts-if.patch
@@ -1,8 +1,8 @@
 diff --git a/chart/templates/daemonset.yaml b/chart/templates/daemonset.yaml
-index 8710693..0da49c3 100644
+index e879906..ec90cb7 100644
 --- a/chart/templates/daemonset.yaml
 +++ b/chart/templates/daemonset.yaml
-@@ -75,11 +75,15 @@ spec:
+@@ -80,11 +80,15 @@ spec:
            name: lib-modules
          - mountPath: /etc/host/hosts
            name: hosts
@@ -18,7 +18,7 @@ index 8710693..0da49c3 100644
        serviceAccountName: {{ include "chart.fullname" . }}-controller-manager
        terminationGracePeriodSeconds: 10
        tolerations:
-@@ -114,7 +118,9 @@ spec:
+@@ -119,7 +123,9 @@ spec:
            path: /etc/hosts
            type: File
          name: hosts
@@ -31,7 +31,7 @@ index 8710693..0da49c3 100644
 +        name: host-fs
 +      {{- end }}
 diff --git a/chart/values.yaml b/chart/values.yaml
-index c47804e..ec96361 100644
+index 967294d..b74acdb 100644
 --- a/chart/values.yaml
 +++ b/chart/values.yaml
 @@ -16,8 +16,8 @@ controllerManager:
@@ -42,6 +42,6 @@ index c47804e..ec96361 100644
 -  hostfsEnabled: "false"
 +  aptEnabled: false
 +  hostfsEnabled: false
+   validationModulePresentEnabled: "true"
  metricsService:
    ports:
-   - name: https

--- a/patches/01-healthport.patch
+++ b/patches/01-healthport.patch
@@ -1,5 +1,5 @@
 diff --git a/chart/templates/daemonset.yaml b/chart/templates/daemonset.yaml
-index 0da49c3..4d7daa4 100644
+index ec90cb7..32bfd37 100644
 --- a/chart/templates/daemonset.yaml
 +++ b/chart/templates/daemonset.yaml
 @@ -19,7 +19,9 @@ spec:
@@ -13,7 +13,7 @@ index 0da49c3..4d7daa4 100644
          - /manager
          env:
          - name: NODE_NAME
-@@ -43,7 +45,7 @@ spec:
+@@ -48,7 +50,7 @@ spec:
          livenessProbe:
            httpGet:
              path: /healthz
@@ -22,7 +22,7 @@ index 0da49c3..4d7daa4 100644
            initialDelaySeconds: 15
            periodSeconds: 20
          name: manager
-@@ -54,7 +56,7 @@ spec:
+@@ -59,7 +61,7 @@ spec:
          readinessProbe:
            httpGet:
              path: /readyz
@@ -32,7 +32,7 @@ index 0da49c3..4d7daa4 100644
            periodSeconds: 10
          resources: {{- toYaml .Values.controllerManager.manager.resources | nindent 10
 diff --git a/chart/values.yaml b/chart/values.yaml
-index ec96361..b4aac5c 100644
+index b74acdb..1c3178a 100644
 --- a/chart/values.yaml
 +++ b/chart/values.yaml
 @@ -4,7 +4,8 @@ controllerManager:


### PR DESCRIPTION
Implements a Validator Webhook that checks that there isn't another NodeConfig with the same modules present as the one being created/updated when using the same NodeSelectors.

This change aims to reduce competing configurations between NodeConfigs.