### PR TITLE
Feature: Verify node status before reconcile

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,7 +24,6 @@ linters:
     - exportloopref
     - ginkgolinter
     - goconst
-    - gocyclo
     - gofmt
     - goimports
     - gosimple

--- a/chart/templates/daemonset.yaml
+++ b/chart/templates/daemonset.yaml
@@ -21,6 +21,9 @@ spec:
       containers:
       - args:
         - --health-probe-bind-address=:{{ .Values.controllerManager.manager.healthPort }}
+        {{- if .Values.managerConfig.ignoreNodeReady }}
+        - --ignore-node-ready=true
+        {{- end }}
         command:
         - /manager
         env:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -19,7 +19,8 @@ kubernetesClusterDomain: cluster.local
 managerConfig:
   aptEnabled: false
   hostfsEnabled: false
-  validationModulePresentEnabled: "true"
+  validationModulePresentEnabled: true
+  ignoreNodeReady: false
 metricsService:
   ports:
   - name: https

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -66,3 +66,21 @@ spec:
 To remove a module's configuration you have to set the `state` field to `absent`
 and apply the CR to the cluster. You can check in the logs if it's been
 successfully removed.
+
+## Configuration
+
+In the helm chart you have these options to configure the `NodeConfig` operator:
+
+- `aptEnabled`: the [`apt` module](/docs/module_reference.md#apt-packages)
+  requires this flag to be set. It also schedules a job to update the apt
+  package cache every 5 hours.
+- `hostfsEnabled`: this flag mounts the host's root filesystem in the controller
+  pod. This flag is required for [some modules][modules].
+- `validationModulePresentEnabled`: this flag enables the validation that checks
+  if a module is defined multiple times for the same node selector in the
+  validation webhook.
+- `ignoreNodeReady`: by default the controller will not reconcile a resource if
+  the node is `NotReady` but you can ignore that check by setting this flag to
+  true.
+
+[modules]: ./module_reference.md

--- a/patches/00-hosts-if.patch
+++ b/patches/00-hosts-if.patch
@@ -40,8 +40,9 @@ index 967294d..b74acdb 100644
  managerConfig:
 -  aptEnabled: "false"
 -  hostfsEnabled: "false"
+-  validationModulePresentEnabled: "true"
 +  aptEnabled: false
 +  hostfsEnabled: false
-   validationModulePresentEnabled: "true"
++  validationModulePresentEnabled: true
  metricsService:
    ports:

--- a/patches/02-ignore-node-ready-flag.patch
+++ b/patches/02-ignore-node-ready-flag.patch
@@ -1,0 +1,26 @@
+diff --git a/chart/templates/daemonset.yaml b/chart/templates/daemonset.yaml
+index 32bfd37..6e201ad 100644
+--- a/chart/templates/daemonset.yaml
++++ b/chart/templates/daemonset.yaml
+@@ -21,6 +21,9 @@ spec:
+       containers:
+       - args:
+         - --health-probe-bind-address=:{{ .Values.controllerManager.manager.healthPort }}
++        {{- if .Values.managerConfig.ignoreNodeReady }}
++        - --ignore-node-ready=false
++        {{- end }}
+         command:
+         - /manager
+         env:
+diff --git a/chart/values.yaml b/chart/values.yaml
+index 1c3178a..3390fce 100644
+--- a/chart/values.yaml
++++ b/chart/values.yaml
+@@ -20,6 +20,7 @@ managerConfig:
+   aptEnabled: false
+   hostfsEnabled: false
+   validationModulePresentEnabled: true
++  ignoreNodeReady: false
+ metricsService:
+   ports:
+   - name: https


### PR DESCRIPTION
This commit adds a check that verifies that the node status is `Ready` before reconciling a request. It also adds a flag to the controller that allows to skip this check.